### PR TITLE
Adding first names to players/profile endpoint

### DIFF
--- a/app/services/players/market_value.py
+++ b/app/services/players/market_value.py
@@ -29,7 +29,7 @@ class TransfermarktPlayerMarketValue(TransfermarktBase):
         """Initialize the TransfermarktPlayerMarketValue class."""
         self.URL = self.URL.format(player_id=self.player_id)
         self.page = self.request_url_page()
-        self.raise_exception_if_not_found(xpath=Players.Profile.NAME)
+        self.raise_exception_if_not_found(xpath=Players.Profile.LAST_NAME)
         self.market_value_chart = self.make_request(url=self.URL_MARKET_VALUE.format(player_id=self.player_id))
 
     def __parse_market_value_history(self) -> list:

--- a/app/services/players/profile.py
+++ b/app/services/players/profile.py
@@ -39,7 +39,8 @@ class TransfermarktPlayerProfile(TransfermarktBase):
         """
         self.response["id"] = self.get_text_by_xpath(Players.Profile.ID)
         self.response["url"] = self.get_text_by_xpath(Players.Profile.URL)
-        self.response["name"] = self.get_text_by_xpath(Players.Profile.NAME)
+        self.response["lastName"] = self.get_text_by_xpath(Players.Profile.LAST_NAME)
+        self.response["firstName"] = self.get_text_by_xpath(Players.Profile.FIRST_NAME)
         self.response["description"] = self.get_text_by_xpath(Players.Profile.DESCRIPTION)
         self.response["fullName"] = self.get_text_by_xpath(Players.Profile.FULL_NAME)
         self.response["nameInHomeCountry"] = self.get_text_by_xpath(Players.Profile.NAME_IN_HOME_COUNTRY)

--- a/app/services/players/transfers.py
+++ b/app/services/players/transfers.py
@@ -24,7 +24,7 @@ class TransfermarktPlayerTransfers(TransfermarktBase):
         """Initialize the TransfermarktPlayerTransfers class."""
         self.URL = self.URL.format(player_id=self.player_id)
         self.page = self.request_url_page()
-        self.raise_exception_if_not_found(xpath=Players.Profile.NAME)
+        self.raise_exception_if_not_found(xpath=Players.Profile.LAST_NAME)
         self.transfer_history = self.make_request(url=self.URL_TRANSFERS.format(player_id=self.player_id))
 
     def __parse_player_transfer_history(self) -> list:

--- a/app/utils/xpath.py
+++ b/app/utils/xpath.py
@@ -18,7 +18,8 @@ class Players:
     class Profile:
         ID = "//tm-subnavigation[@controller='spieler']//@id"
         URL = "//link[@rel='canonical']//@href"
-        NAME = "//h1[@class='data-header__headline-wrapper']//strong//text()"
+        LAST_NAME = "//h1[@class='data-header__headline-wrapper']//strong//text()"
+        FIRST_NAME = "//h1[@class='data-header__headline-wrapper']/text()"
         DESCRIPTION = "//meta[@name='description']//@content"
         IMAGE_URL = "//div[@id='fotoauswahlOeffnen']//img//@src"
         SHIRT_NUMBER = "//span[@class='data-header__shirt-number']//text()"

--- a/tests/players/test_players_profile.py
+++ b/tests/players/test_players_profile.py
@@ -20,7 +20,8 @@ def test_get_player_profile_28003(len_greater_than_0):
         {
             "id": And(str, len_greater_than_0),
             "url": And(str, len_greater_than_0),
-            "name": And(str, len_greater_than_0),
+            "lastName": And(str, len_greater_than_0),
+            "firstName": And(str, len_greater_than_0),
             "description": And(str, len_greater_than_0),
             "nameInHomeCountry": And(str, len_greater_than_0),
             "imageURL": And(str, len_greater_than_0),
@@ -66,7 +67,8 @@ def test_get_player_profile_8198(len_greater_than_0):
         {
             "id": And(str, len_greater_than_0),
             "url": And(str, len_greater_than_0),
-            "name": And(str, len_greater_than_0),
+            "lastName": And(str, len_greater_than_0),
+            "firstName": And(str, len_greater_than_0),
             "description": And(str, len_greater_than_0),
             "fullName": And(str, len_greater_than_0),
             "imageURL": And(str, len_greater_than_0),
@@ -113,7 +115,8 @@ def test_get_player_profile_68290(len_greater_than_0):
         {
             "id": And(str, len_greater_than_0),
             "url": And(str, len_greater_than_0),
-            "name": And(str, len_greater_than_0),
+            "lastName": And(str, len_greater_than_0),
+            "firstName": And(str, len_greater_than_0),
             "description": And(str, len_greater_than_0),
             "fullName": And(str, len_greater_than_0),
             "imageURL": And(str, len_greater_than_0),
@@ -160,7 +163,8 @@ def test_get_player_profile_3373(len_greater_than_0):
         {
             "id": And(str, len_greater_than_0),
             "url": And(str, len_greater_than_0),
-            "name": And(str, len_greater_than_0),
+            "lastName": And(str, len_greater_than_0),
+            "firstName": And(str, len_greater_than_0),
             "description": And(str, len_greater_than_0),
             "fullName": And(str, len_greater_than_0),
             "imageURL": And(str, len_greater_than_0),


### PR DESCRIPTION
Attempt to fix #61 

Summary:
- Replaced Players.Profile.NAME with Players.Profile.LAST_NAME and ad…ded Players.Profile.FIRST_NAME
	In the data header, the players' last names seem to always be in bold, as opposed to first names not being styled
- Updated players services to check for Players.Profile.LAST_NAME instead of Players.Profile.NAME
- Updated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified player identification to use last names in market value and transfer functionalities.
- **New Features**
	- Player profiles now split names into first and last names for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->