### PR TITLE
Fix #91 :  Make fax Optional in club profile

### DIFF
--- a/app/schemas/clubs/profile.py
+++ b/app/schemas/clubs/profile.py
@@ -30,7 +30,7 @@ class ClubProfile(TransfermarktBaseModel):
     address_line_2: str
     address_line_3: str
     tel: str
-    fax: str
+    fax: Optional[str] = None
     website: str
     founded_on: date
     members: Optional[int] = None


### PR DESCRIPTION
Fix #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the fax input for club profiles by making it optional. Users creating or updating profiles can now omit fax details if not available, streamlining the submission process and reducing mandatory fields for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->