### PR TITLE
fix: Add another special character parsing to player profile height

### DIFF
--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -72,7 +72,7 @@ class TransfermarktBaseModel(BaseModel):
     def parse_height(cls, v: str) -> Optional[int]:
         if not v or not any(char.isdigit() for char in v):
             return None
-        return int(v.replace(",", "").replace("m", ""))
+        return int(v.replace(",", "").replace("m", "").replace("،", ""))
 
     @field_validator("days", mode="before", check_fields=False)
     def parse_days(cls, v: str) -> Optional[int]:

--- a/app/schemas/players/profile.py
+++ b/app/schemas/players/profile.py
@@ -74,6 +74,6 @@ class PlayerProfile(TransfermarktBaseModel, AuditMixin):
     market_value: Optional[int]
     agent: Optional[PlayerAgent]
     outfitter: Optional[str]
-    socialMedia: Optional[list[HttpUrl]]
+    socialMedia: Optional[list[str]]
     trainer_profile: Optional[TrainerProfile]
     relatives: Optional[list[Relatives]]


### PR DESCRIPTION
Hello, this fix is solving weird comma character parsing present on height field.

Solves: https://github.com/felipeall/transfermarkt-api/issues/95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved height input processing by accommodating additional comma characters, ensuring more accurate numeric conversions for varied input formats.
- **New Features**
	- Enhanced flexibility in the `PlayerProfile` class by allowing the `socialMedia` attribute to accept a broader range of string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->