### PR TITLE
 Transfer API Improvements

### DIFF
--- a/app/schemas/players/transfers.py
+++ b/app/schemas/players/transfers.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Optional
+from typing import Optional, Literal
 
 from app.schemas.base import AuditMixin, TransfermarktBaseModel
 
@@ -18,6 +18,7 @@ class PlayerTransfer(TransfermarktBaseModel):
     season: str
     market_value: Optional[int]
     fee: Optional[int]
+    transfer_type: Literal["permanent", "loan", "end_of_loan", "free_transfer"]
 
 
 class PlayerTransfers(TransfermarktBaseModel, AuditMixin):

--- a/tests/players/test_players_transfers.py
+++ b/tests/players/test_players_transfers.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 from fastapi import HTTPException
-from schema import And, Optional, Schema
+from schema import And, Optional, Schema, Or
 
 from app.services.players.transfers import TransfermarktPlayerTransfers
 
@@ -36,6 +36,7 @@ def test_get_player_transfers(player_id, len_greater_than_0, regex_integer, rege
                     "upcoming": bool,
                     Optional("marketValue"): And(str, len_greater_than_0, regex_market_value),
                     Optional("fee"): And(str, len_greater_than_0),
+                    "transferType": Or("permanent", "loan", "end_of_loan", "free_transfer"),
                 },
             ],
             "youthClubs": list,
@@ -46,3 +47,6 @@ def test_get_player_transfers(player_id, len_greater_than_0, regex_integer, rege
     assert expected_schema.validate(result)
     assert any("marketValue" in stat for stat in result.get("transfers"))
     assert any("fee" in stat for stat in result.get("transfers"))
+    
+    transfer_types = [transfer.get("transferType") for transfer in result.get("transfers")]
+    assert all(transfer_types), "All transfers should have a transferType"


### PR DESCRIPTION
First of all, thank you for the hard work on this project, Transfermarkt is an incredible source of up to date data and I'm intending on self hosting this and using it for a wider project soon.

During my testing I noticed the transfers endpoint was a bit broken, returning 500s when it came to different types of loans and loan fees etc. I believe there was some HTML tags getting parsed into the responses when only an integer was expected.
There was also no way to differentiate between the different types of transfer, I feel like this is quite an important distinction and it would be really useful for me going forward. I have implemented some changes to the transfer response to make different transfer types obvious.

Please let me know if theres any issues or corrections you would like me to do. Thanks again.

### Initial Issues
500 Error with HTML in Fee Values: The API was failing with a 500 error when processing transfers with special fee values like "Loan fee" or "End of loan" because it was receiving HTML-formatted strings that couldn't be converted to numbers.
Missing Transfer Information: Important transfer context like loan returns and loan transfers was being lost due to validation errors, as the schema expected numeric values for fees.
Inconsistent Data Representation: There was no standardised way to represent different types of transfers (permanent, loans, end of loans, free transfers).
Steps Taken to Fix the Issues
HTML Cleaning:
Added BeautifulSoup to parse and clean HTML tags from fee values
Extracted the meaningful text content from the HTML-formatted strings

Loan handling:
Added logic to identify and preserve special text values like "End of loan" and "loan transfer"
Created a system to properly handle these values without causing validation errors

Fee Value Parsing:
Implemented proper parsing of currency values with different formats (€, k, m suffixes)
Converted string fee values to integers for consistent representation
Made the fee field truly optional, only including it when a value is present

### Additional Fields Added
Transfer Type Field:

Added a new transferType field to explicitly categorize transfers

Implemented four standard transfer types:

permanent: Regular transfers with fees
loan: Temporary transfers, with or without fees
end_of_loan: Returns to parent clubs after loan periods
free_transfer: Transfers without fees, including youth promotions
Schema Updates:
Updated the schema to include the new transferType field with appropriate validation
Ensured the schema properly handles optional fee values

### Test Improvements:
Updated tests to verify that all transfers have appropriate transfer types

These improvements ensure the API now provides comprehensive and accurate transfer information for all players, regardless of their transfer history complexity, while maintaining a consistent and well-structured response format.