### PR TITLE
Fix: Set default for assists field to None in PlayerStat model

### DIFF
--- a/app/schemas/players/stats.py
+++ b/app/schemas/players/stats.py
@@ -10,7 +10,7 @@ class PlayerStat(TransfermarktBaseModel):
     club_id: str
     appearances: Optional[int]
     goals: Optional[int]
-    assists: Optional[int]
+    assists: Optional[int] = None
     yellow_cards: Optional[int]
     red_cards: Optional[int]
     minutes_played: Optional[int]


### PR DESCRIPTION
This PR fixes a validation error encountered when the Transfermarkt API returns player stats without an "assists" field or with a placeholder value (such as "-"). The change made was this:

Updated the `PlayerStat` model to set a default value of `None` for `assists`, ensuring the API doesn't raise validation errors when this field is missing.

```python
class PlayerStat(TransfermarktBaseModel):
    competition_id: str
    competition_name: str
    season_id: str
    club_id: str
    appearances: Optional[int]
    goals: Optional[int]
    assists: Optional[int] = None  # Set default to None to avoid validation errors
    yellow_cards: Optional[int]
    red_cards: Optional[int]
    minutes_played: Optional[int]
```
I have verified this change both through unit tests and manual testing. Specifically:

- I ran the API locally and retrieved stats for every Premier League player.
- The `assists` field now correctly handles missing or placeholder values (e.g., "-") and sets them to `None`, preventing validation errors.
- All expected data loaded successfully without triggering `ResponseValidationError`.
